### PR TITLE
Fix app link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This app adds support for the Z-wave devices by [Heatit controls](http://www.hea
 </a>  
 
 ## Links:
-[Heatit app at Athom apps](https://apps.athom.com/app/no.ThermoFloor)                      
+[Heatit app at Athom apps](https://apps.athom.com/app/no.thermofloor)                      
 [Heatit Github repository](https://github.com/TedTolboom/no.ThermoFloor)             
 
 ## Devices supported:


### PR DESCRIPTION
Seems that app link to homey store doesn't work due to camel case.